### PR TITLE
[fix] FieldSquareの上に文字が表示されないバグを修正した

### DIFF
--- a/kyon/src/Button.cpp
+++ b/kyon/src/Button.cpp
@@ -3,9 +3,9 @@
 
 
 namespace kyon {
-Button::Button() : rect(0, 0, 60, 60), pos(60, 60), clickNum(0) {}
+Button::Button() : rect(0, 0, 60, 60), pos(60, 60), clickNum(0), font(20) {}
 
-Button::Button(uint32 h, uint32 w, uint32 fontSize, String str) : rect(0, 0, h, w), font(fontSize), pos(h, w), rectStr(str) {}
+Button::Button(uint32 h, uint32 w, uint32 fontSize, String str ) : rect(0, 0, h, w), font(fontSize), pos(h, w) , rectStr(str)  {}
 
 //座標設定
 Button& Button::setPos(uint32 x, uint32 y) {


### PR DESCRIPTION
`FieldSquare` の親クラスの `Button` 側の `font` のサイズが指定されていなかったため `FieldSquare` のrectの上に文字が表示されなかったバグを修正しました